### PR TITLE
Check if dbFilters is empty string before appyling filters.

### DIFF
--- a/src/uk/sipperfly/utils/CommonUtil.java
+++ b/src/uk/sipperfly/utils/CommonUtil.java
@@ -122,7 +122,7 @@ public class CommonUtil {
 	public static boolean checkIgnoreFiles(String fileName, String dbFilters) {
 		boolean ignore = false;
 
-		if (dbFilters != null) {
+		if (dbFilters != null && !dbFilters.equals("")) {
 			List<String> filterList = Arrays.asList(dbFilters.split(","));
 
 			int lastIndex = fileName.lastIndexOf('.');


### PR DESCRIPTION
These 2 lines in `Exactly.java` indicate that there may have once been a feature that allowed users to filter out certain file extensions, but now is hard-coded to always be an empty string.

`String filters = "";//this.filterField.getText();`
`this.uIManager.saveLocationAndFilter(inputDirText, filters);`

This causes 2 problems.

1. All extensionless files will be filtered out of bag creation.
2. Exactly won't be aware that the extensionless files were filtered out and will confuse the verification process, resulting in a crash.

**The change I am proposing is to simply check if `dbFilters` is an empty string before applying the filters.**

This effectively renders the `checkIgnoreFiles(String fileName, String dbFilters)` function pointless, as it will always return false due to the hardcoded `String filters = "";`, but it does solve the problem with minimal refactoring.

If my assumption about this code being an artifact of an incomplete/rolled-back feature is correct and there is no desire to ever full implement that feature, then I think this function should be deleted entirely along with the `String filters` variable in the `Configuration` class.